### PR TITLE
createReview시 서버 응답 값 그대로 전달

### DIFF
--- a/Misik/WebView/WebViewController.swift
+++ b/Misik/WebView/WebViewController.swift
@@ -169,15 +169,7 @@ extension WebViewController: OCRViewController.Delegate {
                 return
             }
             
-            // TODO: 포멧 최적화 필요
-            let formatted = polished.parsed.compactMap { item -> [String : String]? in
-                guard let key = item["key"], let value = item["value"] else {
-                    return nil
-                }
-                return [key : value]
-            }
-            
-            webviewCommandSender.sendScanResults(results: formatted)
+            webviewCommandSender.sendScanResults(results: polished)
             dismiss(animated: true)
         }
     }
@@ -217,7 +209,7 @@ extension DebugWebViewController {
                     },
                     receiveScanResult: function(results) {
                         console.log("📩 iOS에서 받은 스캔 결과:", results);
-                        document.getElementById("scanOutput").innerText = "받은 스캔 결과: " + JSON.stringify(results);
+                        document.getElementById("scanOutput").innerText = results;
                     }
                 };
 

--- a/Misik/WebView/WebViewSendCommandHandler.swift
+++ b/Misik/WebView/WebViewSendCommandHandler.swift
@@ -15,7 +15,7 @@ class WebViewCommandSender {
     }
     
     /// Scan 결과를 웹뷰의 JavaScript 함수로 전달
-    func sendScanResults(results: [[String: String]]) {
+    func sendScanResults(results: String) {
         callJavaScript(functionName: "receiveScanResult", params: results)
     }
     
@@ -26,13 +26,22 @@ class WebViewCommandSender {
     
     /// JavaScript 함수 호출을 수행하는 메서드
     private func callJavaScript(functionName: String, params: Any) {
-        guard let jsonData = try? JSONSerialization.data(withJSONObject: params, options: [.withoutEscapingSlashes]),
-              let jsonString = String(data: jsonData, encoding: .utf8) else {
-            print("JSON 직렬화 실패")
-            return
+        
+        let paramsStr: String
+        
+        if let casted = params as? String {
+            paramsStr = casted
+        } else {
+            guard let jsonData = try? JSONSerialization.data(withJSONObject: params, options: [.withoutEscapingSlashes]),
+                  let jsonString = String(data: jsonData, encoding: .utf8) else {
+                print("JSON 직렬화 실패")
+                return
+            }
+            
+            paramsStr = jsonString
         }
         
-        let jsCode = "window.response.\(functionName)('\(jsonString)');"
+        let jsCode = "window.response.\(functionName)('\(paramsStr)');"
         
         DispatchQueue.main.async {
             self.webView.evaluateJavaScript(jsCode) { result, error in


### PR DESCRIPTION
## Fix
- Client > Web으로 전송되는 이벤트 중, createReview에 대해, /review/ocr-parsed 서버 응답 값 그대로 전달하도록 수정

## Result
- 기존 파싱 로직 제거 및 응닶값 String 으로 그대로 넘길 수 있도록 디코딩 로직 추가